### PR TITLE
[Closes #17] Implemented invalid dynamic calls rule.

### DIFF
--- a/src/elvis_code.erl
+++ b/src/elvis_code.erl
@@ -114,10 +114,17 @@ print_node(Node) ->
 
 -spec print_node(tree_node(), integer()) -> ok.
 print_node(Node = #{type := Type}, CurrentLevel) ->
-    Indentation = lists:duplicate(CurrentLevel * 4, 32),
-    {Line, _} = elvis_code:attr(location, Node),
-    lager:info("~s - [~p] ~p : ~p~n",
-               [Indentation, CurrentLevel, Type, Line]).
+    Type = type(Node),
+    Indentation = lists:duplicate(CurrentLevel * 4, $ ),
+    Content = content(Node),
+    % {Line, _} = elvis_code:attr(location, Node),
+    lager:info(
+      "~s - [~p] ~p~n",
+      [Indentation, CurrentLevel, Type]
+     ),
+    lists:map(fun(Child) -> print_node(Child, CurrentLevel + 1) end, Content),
+    ok.
+
 
 %% @private
 %% @doc Takes a node type and determines its nesting level increment.
@@ -245,13 +252,13 @@ to_map({var, Location, Name}) ->
 %% Function call
 
 to_map({call, Location, Function, Arguments}) ->
-    #{type => var,
+    #{type => call,
       attrs => #{location => Location,
                  function => to_map(Function),
                  arguments => to_map(Arguments)}};
 
 to_map({remote, Location, Module, Function}) ->
-    #{type => var,
+    #{type => remote,
       attrs => #{location => Location,
                  module => to_map(Module),
                  function => to_map(Function)}};

--- a/test/examples/fail_invalid_dynamic_call.erl
+++ b/test/examples/fail_invalid_dynamic_call.erl
@@ -1,0 +1,36 @@
+-module(fail_invalid_dynamic_call).
+
+-export([
+         dynamic_module_name_call/0,
+         dynamic_function_name_call/0,
+         another_dynamic_module_name_call/0,
+         dynamic_module_name_call_in_case/0
+        ]).
+
+dynamic_module_name_call() ->
+    normal:call(),
+    Module = a_module,
+    Module:call().
+
+dynamic_function_name_call() ->
+    normal:call(),
+    Function = a_function,
+    a_module:Function(),
+    normal:call().
+
+another_dynamic_module_name_call() ->
+    normal:call(),
+    another_normal:call(),
+    Module = another_module,
+    Module:call_to_function(),
+    Module:call_to__another_function().
+
+dynamic_module_name_call_in_case() ->
+    normal:call(),
+    another_normal:call(),
+    case 1 of
+        1 ->
+            Module = another_module,
+            Module:call_to_function();
+        2 -> ok
+    end.

--- a/test/examples/pass_invalid_dynamic_call.erl
+++ b/test/examples/pass_invalid_dynamic_call.erl
@@ -1,0 +1,39 @@
+-module(pass_invalid_dynamic_call).
+
+-export([
+         dynamic_module_name_call/0,
+         dynamic_function_name_call/0,
+         another_dynamic_module_name_call/0,
+         dynamic_module_name_call_in_case/0
+        ]).
+
+-callback init(Arg :: any()) ->
+    any().
+
+dynamic_module_name_call() ->
+    normal:call(),
+    Module = a_module,
+    Module:call().
+
+dynamic_function_name_call() ->
+    normal:call(),
+    Function = a_function,
+    a_module:Function(),
+    normal:call().
+
+another_dynamic_module_name_call() ->
+    normal:call(),
+    another_normal:call(),
+    Module = another_module,
+    Module:call_to_function(),
+    Module:call_to__another_function().
+
+dynamic_module_name_call_in_case() ->
+    normal:call(),
+    another_normal:call(),
+    case 1 of
+        1 ->
+            Module = another_module,
+            Module:call_to_function();
+        2 -> ok
+    end.

--- a/test/rules_SUITE.erl
+++ b/test/rules_SUITE.erl
@@ -14,7 +14,8 @@
          verify_operator_spaces/1,
          verify_nesting_level/1,
          verify_god_modules/1,
-         verify_no_if_expression/1
+         verify_no_if_expression/1,
+         verify_invalid_dynamic_call/1
         ]).
 
 -define(EXCLUDED_FUNS,
@@ -145,3 +146,21 @@ verify_no_if_expression(_Config) ->
     [#{line_num := 9},
      #{line_num := 20},
      #{line_num := 29}] = elvis_style:no_if_expression(ElvisConfig, File, []).
+
+-spec verify_invalid_dynamic_call(config()) -> any().
+verify_invalid_dynamic_call(_Config) ->
+    ElvisConfig = elvis_config:default(),
+    #{src_dirs := SrcDirs} = ElvisConfig,
+
+    PathFail = "fail_invalid_dynamic_call.erl",
+    {ok, FileFail} = elvis_test_utils:find_file(SrcDirs, PathFail),
+    [
+     #{line_num := 13},
+     #{line_num := 25},
+     #{line_num := 26},
+     #{line_num := 34}
+    ] = elvis_style:invalid_dynamic_call(ElvisConfig, FileFail, []),
+
+    PathPass = "pass_invalid_dynamic_call.erl",
+    {ok, FilePass} = elvis_test_utils:find_file(SrcDirs, PathPass),
+    [] = elvis_style:invalid_dynamic_call(ElvisConfig, FilePass, []).


### PR DESCRIPTION
- Fixed bug when generating `call` and `remote` parse tree nodes.
