### PR TITLE
[Closes #17] Implemented 'used ignored variable' rule.

### DIFF
--- a/src/elvis_code.erl
+++ b/src/elvis_code.erl
@@ -67,14 +67,20 @@ find(Pred, Node, Results) ->
 
 -spec type(tree_node()) -> atom().
 type(#{type := Type}) ->
-    Type.
+    Type;
+type(undefined) ->
+    undefined.
 
 -spec attr(term(), tree_node()) -> term() | undefined.
 attr(Key, #{attrs := Attrs}) ->
     case maps:is_key(Key, Attrs) of
         true -> maps:get(Key, Attrs);
         false -> undefined
-    end.
+    end;
+attr(_Key, Node) when is_map(Node) ->
+    undefined;
+attr(_Key, undefined) ->
+    undefined.
 
 -spec content(tree_node()) -> [tree_node()].
 content(#{content := Content}) ->

--- a/test/examples/fail_no_if_expression.erl
+++ b/test/examples/fail_no_if_expression.erl
@@ -8,7 +8,7 @@
 uses_if(Arg) ->
     if
         Arg -> ok;
-        false -> not_ok
+        Arg == false -> not_ok
     end,
     case 1 of
         1 -> ok;
@@ -19,7 +19,7 @@ uses_if(Arg) ->
 uses_if_twice(Arg) ->
     if
         Arg -> ok;
-        false -> not_ok
+        Arg == false -> not_ok
     end,
     case 1 of
         1 -> ok;
@@ -28,5 +28,5 @@ uses_if_twice(Arg) ->
     end,
     if
         Arg -> ok;
-        false -> not_ok
+        Arg == false -> not_ok
     end.

--- a/test/examples/fail_used_ignored_variable.erl
+++ b/test/examples/fail_used_ignored_variable.erl
@@ -1,0 +1,17 @@
+-module(fail_used_ignored_variable).
+
+-export([
+         use_ignored_var/2,
+         use_ignored_var_in_fun/2
+        ]).
+
+use_ignored_var(_One, Two) ->
+    Three = _One + Two,
+    case Three of
+        _Four ->
+            _Four
+    end.
+
+use_ignored_var_in_fun(_One, Two) ->
+    Fun = fun (_Three) -> _One + _Three end,
+    Fun(Two).

--- a/test/rules_SUITE.erl
+++ b/test/rules_SUITE.erl
@@ -15,7 +15,8 @@
          verify_nesting_level/1,
          verify_god_modules/1,
          verify_no_if_expression/1,
-         verify_invalid_dynamic_call/1
+         verify_invalid_dynamic_call/1,
+         verify_used_ignored_variable/1
         ]).
 
 -define(EXCLUDED_FUNS,
@@ -164,3 +165,16 @@ verify_invalid_dynamic_call(_Config) ->
     PathPass = "pass_invalid_dynamic_call.erl",
     {ok, FilePass} = elvis_test_utils:find_file(SrcDirs, PathPass),
     [] = elvis_style:invalid_dynamic_call(ElvisConfig, FilePass, []).
+
+-spec verify_used_ignored_variable(config()) -> any().
+verify_used_ignored_variable(_Config) ->
+    ElvisConfig = elvis_config:default(),
+    #{src_dirs := SrcDirs} = ElvisConfig,
+    Path = "fail_used_ignored_variable.erl",
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, Path),
+    [
+     #{line_num := 9},
+     #{line_num := 12},
+     #{line_num := 16},
+     #{line_num := 16}
+    ] = elvis_style:used_ignored_variable(ElvisConfig, File, []).


### PR DESCRIPTION
- Removed pattern matching in test for an `elvis_code:tree_node()`.
