### PR TITLE
[Closes #59] Using API to get files' content

### DIFF
--- a/src/elvis_code.erl
+++ b/src/elvis_code.erl
@@ -475,8 +475,43 @@ to_map({op, Location, Operation, Single}) ->
                  operation => Operation},
       content => to_map([Single])};
 
-%% Attributes
+%% Record
 
+to_map({record, Location, Name, Fields}) ->
+    #{type => record,
+      attrs => #{location => Location,
+                 name => Name},
+      content => to_map(Fields)};
+to_map({record, Location, Var, Name, Fields}) ->
+    #{type => record,
+      attrs => #{location => Location,
+                 variable => to_map(Var),
+                 name => Name},
+      content => to_map(Fields)};
+
+to_map({record_index, Location, Name, Field}) ->
+    #{type => record_index,
+      attrs => #{location => Location,
+                 name => Name},
+      content => [to_map(Field)]};
+
+to_map({record_field, Location, Name}) ->
+    #{type => record_field,
+      attrs => #{location => Location,
+                 name => to_map(Name)}};
+to_map({record_field, Location, Name, Default}) ->
+    #{type => record_field,
+      attrs => #{location => Location,
+                 default => to_map(Default),
+                 name => to_map(Name)}};
+to_map({record_field, Location, Var, Name, Field}) ->
+    #{type => record_field,
+      attrs => #{location => Location,
+                 variable => to_map(Var),
+                 name => Name},
+      content => [to_map(Field)]};
+
+%% Attributes
 
 to_map({attribute, Location, Type, Value}) ->
     #{type => Type,


### PR DESCRIPTION
`elvis` was trying to get the content of each file in a PR, using the public `github.com` url returned through the API, but this way of accessing requires authentication information in a cookie. The right way for getting the contents of a file is through the api call also provided in the PR files list. 
