### PR TITLE
[#93] Added handling for unhandled and unexpected abstract forms.

### DIFF
--- a/src/elvis_code.erl
+++ b/src/elvis_code.erl
@@ -683,6 +683,9 @@ to_map({typed_record_field, Field, Type}) ->
                  text => attr(text, FieldMap),
                  field => FieldMap,
                  type => to_map(Type)}};
+
+%% Type
+
 to_map({type, Attrs, Subtype, Types}) ->
     {Location, Text} =
         case Attrs of
@@ -708,6 +711,8 @@ to_map({ann_type, Attrs, [Var, Type]}) ->
                  text => get_text(Attrs),
                  var => to_map(Var),
                  type => to_map(Type)}};
+to_map(any) -> %% any()
+    #{type => any};
 
 %% Other Attributes
 


### PR DESCRIPTION
The error message reported on #93 was misleading since the actual error was an unhandled `ann_type` in an [`escalus / include / escalus.hrl`](https://github.com/esl/escalus/blob/af0a385b53da5966fb2d031d8f9e5f121c91af5a/include/escalus.hrl#L28).
