### PR TITLE
[Fix #92] Fixed bug.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = elvis
 
-DEPS = lager sync getopt jiffy ibrowse aleppo
+DEPS = lager sync getopt jiffy ibrowse aleppo zipper
 TEST_DEPS = meck
 
 dep_lager = git https://github.com/basho/lager.git 2.0.3
@@ -10,6 +10,7 @@ dep_meck = git https://github.com/eproxus/meck master
 dep_jiffy = git https://github.com/davisp/jiffy 0.11.3
 dep_ibrowse = git https://github.com/cmullaparthi/ibrowse v4.1.1
 dep_aleppo = git https://github.com/inaka/aleppo master
+dep_zipper = git https://github.com/inaka/zipper 0.1.0
 
 include erlang.mk
 

--- a/rebar.config
+++ b/rebar.config
@@ -30,4 +30,4 @@
  ]
 }.
 {escript_name, "elvis"}.
-{escript_incl_apps, [getopt, jiffy, ibrowse, aleppo]}.
+{escript_incl_apps, [getopt, jiffy, ibrowse, aleppo, zipper]}.

--- a/test/examples/fail_used_ignored_variable.erl
+++ b/test/examples/fail_used_ignored_variable.erl
@@ -2,7 +2,8 @@
 
 -export([
          use_ignored_var/2,
-         use_ignored_var_in_fun/2
+         use_ignored_var_in_fun/2,
+         no_used_ignored_vars_here/2
         ]).
 
 use_ignored_var(_One, Two) ->
@@ -15,3 +16,6 @@ use_ignored_var(_One, Two) ->
 use_ignored_var_in_fun(_One, Two) ->
     Fun = fun (_Three) -> _One + _Three end,
     Fun(Two).
+
+no_used_ignored_vars_here(One, _Two) ->
+    {_Bla} = One.

--- a/test/rules_SUITE.erl
+++ b/test/rules_SUITE.erl
@@ -175,10 +175,10 @@ verify_used_ignored_variable(_Config) ->
     Path = "fail_used_ignored_variable.erl",
     {ok, File} = elvis_test_utils:find_file(SrcDirs, Path),
     [
-     #{line_num := 9},
-     #{line_num := 12},
-     #{line_num := 16},
-     #{line_num := 16}
+     #{line_num := 10},
+     #{line_num := 13},
+     #{line_num := 17},
+     #{line_num := 17}
     ] = elvis_style:used_ignored_variable(ElvisConfig, File, []).
 
 -spec verify_no_behavior_info(config()) -> any().


### PR DESCRIPTION
Used zipper to find a parent node of type `match` and check if the child is on the left or right side of the `=` operator.
