### PR TITLE
halt(1) after 'elvis rock' invocation fails.

### DIFF
--- a/src/elvis.erl
+++ b/src/elvis.erl
@@ -192,7 +192,10 @@ process_options([], Cmds, Config) ->
 
 -spec process_commands([string()], elvis_config:config()) -> ok.
 process_commands([rock | Cmds], Config) ->
-    _ = rock(Config),
+    case rock(Config) of
+        {fail, _} -> elvis_utils:erlang_halt(1);
+        ok -> ok
+    end,
     process_commands(Cmds, Config);
 process_commands([help | Cmds], Config) ->
     Config = help(Config),
@@ -206,7 +209,7 @@ process_commands(['git-hook' | Cmds], Config) ->
 process_commands([], _Config) ->
     ok;
 process_commands([_Cmd | _Cmds], _Config) ->
-    throw(unrecognized_or_unimplemened_command).
+    throw(unrecognized_or_unimplemented_command).
 
 %%% Options
 


### PR DESCRIPTION
This makes 'elvis rock' usable in e.g. continuous integration systems or other
automation relying on the usual shell return codes to detect failure.
Cf. https://github.com/inaka/elvis/issues/175

This change also:
- fixes a couple of typos (unimplemened -> unimplemented, emtpy -> empty);
- adds mocks for erlang_utils:erlang_halt around every invocation of main()
  that calls 'rocks';
- standardizes use of meck:unload/1 throughout - some were in 'catch'
  expressions, some not; this doesn't appear to be necessary.
