### PR TITLE
removed ssh addressed repos

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -21,15 +21,15 @@
 {deps_dir, "deps"}.
 {deps,
  [
-  {lager,   "2.*", {git, "git@github.com:basho/lager.git",          "2.0.0"}},
-  {getopt,  "0.*", {git, "git@github.com:jcomellas/getopt.git",     "v0.8.2"}},
-  {meck,    "0.*", {git, "git@github.com:eproxus/meck.git",         "0.8.2"}},
-  {jiffy,   "0.*", {git, "git@github.com:davisp/jiffy.git",         "0.11.3"}},
-  {ibrowse, "4.*", {git, "git@github.com:cmullaparthi/ibrowse.git", "v4.1.1"}},
-  {aleppo,  "0.*", {git, "git@github.com:inaka/aleppo.git",         "0.9.0"}},
-  {zipper,  ".*",  {git, "git@github.com:inaka/zipper.git",         "0.1.0"}},
-  {egithub, ".*",  {git, "git@github.com:inaka/erlang-github.git",  "0.1.1"}},
-  {katana, ".*",  {git, "git@github.com:inaka/erlang-katana",       "0.2.0"}}
+  {lager,   "2.*", {git, "git://github.com/basho/lager.git",          "2.0.0"}},
+  {getopt,  "0.*", {git, "git://github.com/jcomellas/getopt.git",     "v0.8.2"}},
+  {meck,    "0.*", {git, "git://github.com/eproxus/meck.git",         "0.8.2"}},
+  {jiffy,   "0.*", {git, "git://github.com/davisp/jiffy.git",         "0.11.3"}},
+  {ibrowse, "4.*", {git, "git://github.com/cmullaparthi/ibrowse.git", "v4.1.1"}},
+  {aleppo,  "0.*", {git, "git://github.com/inaka/aleppo.git",         "0.9.0"}},
+  {zipper,  ".*",  {git, "git://github.com/inaka/zipper.git",         "0.1.0"}},
+  {egithub, ".*",  {git, "git://github.com/inaka/erlang-github.git",  "0.1.1"}},
+  {katana, ".*",  {git, "git://github.com/inaka/erlang-katana",       "0.2.0"}}
  ]
 }.
 {escript_name, "elvis"}.


### PR DESCRIPTION
when cloning a repo use the ssh address, when users or CIs download code use the git://github.com/user/repo format.
