### PR TITLE
Bypass operator_spaces when unable to find node type

### DIFF
--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -446,6 +446,7 @@ check_operator_spaces_rule(Line, Num, {Position, Operator}, Root) ->
                        {ok, Node} -> ktn_code:type(Node)
                    end,
             case Type of
+                undefined -> [];
                 atom -> [];
                 binary_element -> [];
                 string -> [];


### PR DESCRIPTION
Elvis reported erroneously that there is a missing space in https://github.com/for-GET/katt/blob/38a71342aa33ce23f01efce8557a2c71b61e37f0/src/katt_util.erl#L329

After investigating, it seems that elvis (or actually katana) is unable to find the node. My guess is that the guard is too naïve https://github.com/inaka/elvis/blob/2ac9651e45de240e3531943d22d1ea5de433dbd5/src/elvis_code.erl#L75 but I'm not going to investigate that now.

Regardless of the core reason, if elvis find a possible error, but cannot verify that it is indeed an error (in this case find the node), it's better to keep quiet (no false positives).