### PR TITLE
Revert "Bypass operator_spaces when unable to find node type"

### DIFF
--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -446,7 +446,6 @@ check_operator_spaces_rule(Line, Num, {Position, Operator}, Root) ->
                        {ok, Node} -> ktn_code:type(Node)
                    end,
             case Type of
-                undefined -> [];
                 atom -> [];
                 binary_element -> [];
                 string -> [];


### PR DESCRIPTION
Reverts inaka/elvis#189

> I'm reverting this PR because it breaks [this test](https://github.com/inaka/elvis/blob/master/test/style_SUITE.erl#L122).
> The line (in the code) that goes undetected is this one:
> ```erlang
>   _Unless = [we, consider]++ [operands, as, well],
> ```
> 
> We must find a way to handle both @andreineculau's scenario *and also* the currently tested one.