### PR TITLE
Rule to enforce dependency url fetch protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - [#195] elvis_webhook as an egithub_webhook
+- [#185] Rule to enforce dependency url fetch protocol
 
 ### Deprecated
 

--- a/config/elvis-test.config
+++ b/config/elvis-test.config
@@ -30,11 +30,13 @@
        },
       #{dirs => ["."],
         filter => "Makefile",
-        rules => [{elvis_project, no_deps_master_erlang_mk, #{ignore => []}}]
+        rules => [{elvis_project, no_deps_master_erlang_mk, #{ignore => []}},
+                  {elvis_project, git_for_deps_erlang_mk, #{ignore => []}}]
        },
       #{dirs => ["."],
         filter => "rebar.config",
-        rules => [{elvis_project, no_deps_master_rebar, #{ignore => []}}]
+        rules => [{elvis_project, no_deps_master_rebar, #{ignore => []}},
+                  {elvis_project, git_for_deps_rebar, #{ignore => []}}]
        },
       #{dirs => ["."],
         filter => "elvis.config",

--- a/config/elvis.config
+++ b/config/elvis.config
@@ -30,11 +30,13 @@
        },
       #{dirs => ["."],
         filter => "Makefile",
-        rules => [{elvis_project, no_deps_master_erlang_mk, #{ignore => [sync]}}]
+        rules => [{elvis_project, no_deps_master_erlang_mk, #{ignore => []}},
+                  {elvis_project, git_for_deps_erlang_mk, #{ignore => []}}]
        },
       #{dirs => ["."],
         filter => "rebar.config",
-        rules => [{elvis_project, no_deps_master_rebar, #{ignore => []}}]
+        rules => [{elvis_project, no_deps_master_rebar, #{ignore => []}},
+                  {elvis_project, git_for_deps_rebar, #{ignore => []}}]
        },
       #{dirs => ["."],
         filter => "elvis.config",

--- a/config/old/elvis-test-rule-config-list.config
+++ b/config/old/elvis-test-rule-config-list.config
@@ -29,11 +29,13 @@
        },
       #{dirs => ["."],
         filter => "Makefile",
-        rules => [{elvis_project, no_deps_master_erlang_mk, []}]
+        rules => [{elvis_project, no_deps_master_erlang_mk, #{ignore => []}},
+                  {elvis_project, git_for_deps_erlang_mk, #{ignore => []}}]
        },
       #{dirs => ["."],
         filter => "rebar.config",
-        rules => [{elvis_project, no_deps_master_rebar, []}]
+        rules => [{elvis_project, no_deps_master_rebar, #{ignore => []}},
+                  {elvis_project, git_for_deps_rebar, #{ignore => []}}]
        },
       #{dirs => ["."],
         filter => "elvis.config",

--- a/config/test.config
+++ b/config/test.config
@@ -30,11 +30,13 @@
        },
       #{dirs => ["."],
         filter => "Makefile",
-        rules => [{elvis_project, no_deps_master_erlang_mk, #{ignore => []}}]
+        rules => [{elvis_project, no_deps_master_erlang_mk, #{ignore => []}},
+                  {elvis_project, git_for_deps_erlang_mk, #{ignore => []}}]
        },
       #{dirs => ["."],
         filter => "rebar.config",
-        rules => [{elvis_project, no_deps_master_rebar, #{ignore => []}}]
+        rules => [{elvis_project, no_deps_master_rebar, #{ignore => []}},
+                  {elvis_project, git_for_deps_rebar, #{ignore => []}}]
        },
       #{dirs => ["."],
         filter => "elvis.config",

--- a/test/examples/Makefile.fail
+++ b/test/examples/Makefile.fail
@@ -4,13 +4,13 @@ DEPS = lager sync getopt jiffy ibrowse aleppo zipper
 TEST_DEPS = meck
 
 dep_lager = git https://github.com/basho/lager.git 2.0.3
-dep_sync = git https://github.com/rustyio/sync.git master
-dep_getopt = git https://github.com/jcomellas/getopt v0.8.2
+dep_sync = git git@github.com:rustyio/sync.git master
+dep_getopt = git git://github.com/jcomellas/getopt v0.8.2
 dep_meck = git https://github.com/eproxus/meck master
-dep_jiffy = git https://github.com/davisp/jiffy 0.11.3
-dep_ibrowse = git https://github.com/cmullaparthi/ibrowse v4.1.1
-dep_aleppo = git https://github.com/inaka/aleppo master
-dep_zipper = git https://github.com/inaka/zipper 0.1.0
+dep_jiffy = git git://github.com/davisp/jiffy 0.11.3
+dep_ibrowse = git git://github.com/cmullaparthi/ibrowse v4.1.1
+dep_aleppo = git git://github.com/inaka/aleppo master
+dep_zipper = git git://github.com/inaka/zipper 0.1.0
 
 include erlang.mk
 

--- a/test/examples/rebar.config.fail
+++ b/test/examples/rebar.config.fail
@@ -21,12 +21,12 @@
 {deps_dir, "deps"}.
 {deps,
  [
-  {lager, "2.*", {git, "git@github.com:basho/lager.git", "2.0.0"}},
+  {lager, "2.*", {git, "https://github.com/basho/lager.git", "2.0.0"}},
   {getopt, "0.*", {git, "git@github.com:jcomellas/getopt.git", {branch, "master"}}},
-  {meck, "0.*", {git, "git@github.com:eproxus/meck.git", "0.8.2"}},
-  {jiffy, "0.*", {git, "git@github.com:davisp/jiffy.git", "0.11.3"}},
-  {ibrowse, "4.*", {git, "git@github.com:cmullaparthi/ibrowse.git", "v4.1.1"}},
-  {aleppo, "0.*", {git, "git@github.com:inaka/aleppo.git", "master"}}
+  {meck, "0.*", {git, "git://github.com/eproxus/meck.git", "0.8.2"}},
+  {jiffy, "0.*", {git, "git://github.com/davisp/jiffy.git", "0.11.3"}},
+  {ibrowse, "4.*", {git, "git://github.com/cmullaparthi/ibrowse.git", "v4.1.1"}},
+  {aleppo, "0.*", {git, "git://github.com/inaka/aleppo.git", "master"}}
  ]
 }.
 {escript_name, "elvis"}.

--- a/test/project_SUITE.erl
+++ b/test/project_SUITE.erl
@@ -9,6 +9,8 @@
 -export([
          verify_no_deps_master_erlang_mk/1,
          verify_no_deps_master_rebar/1,
+         verify_git_for_deps_erlang_mk/1,
+         verify_git_for_deps_rebar/1,
          verify_old_config_format/1
         ]).
 
@@ -81,6 +83,43 @@ verify_no_deps_master_rebar(_Config) ->
 
     RuleConfig1 =  #{ignore => [aleppo, getopt]},
     [] = elvis_project:no_deps_master_rebar(ElvisConfig, File, RuleConfig1).
+
+
+-spec verify_git_for_deps_erlang_mk(config()) -> any().
+verify_git_for_deps_erlang_mk(_Config) ->
+    ElvisConfig = elvis_config:default(),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    Filename = "Makefile.fail",
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, Filename),
+
+    [_, _, _] = elvis_project:git_for_deps_erlang_mk(ElvisConfig, File, #{}),
+
+    RuleConfig =  #{ignore => [sync]},
+    [_, _] = elvis_project:git_for_deps_erlang_mk(ElvisConfig,
+                                                  File,
+                                                  RuleConfig),
+
+    RuleConfig1 = #{ignore => [sync, meck]},
+    [_] = elvis_project:git_for_deps_erlang_mk(ElvisConfig,
+                                               File,
+                                               RuleConfig1).
+
+-spec verify_git_for_deps_rebar(config()) -> any().
+verify_git_for_deps_rebar(_Config) ->
+    ElvisConfig = elvis_config:default(),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    Filename = "rebar.config.fail",
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, Filename),
+
+    [_, _] = elvis_project:git_for_deps_rebar(ElvisConfig, File, #{}),
+
+    RuleConfig =  #{ignore => [aleppo]},
+    [_] = elvis_project:git_for_deps_rebar(ElvisConfig, File, RuleConfig),
+
+    RuleConfig1 =  #{ignore => [aleppo, lager]},
+    [] = elvis_project:git_for_deps_rebar(ElvisConfig, File, RuleConfig1).
 
 -spec verify_old_config_format(config()) -> any().
 verify_old_config_format(_Config) ->

--- a/test/project_SUITE.erl
+++ b/test/project_SUITE.erl
@@ -115,10 +115,10 @@ verify_git_for_deps_rebar(_Config) ->
 
     [_, _] = elvis_project:git_for_deps_rebar(ElvisConfig, File, #{}),
 
-    RuleConfig =  #{ignore => [aleppo]},
+    RuleConfig =  #{ignore => [getopt]},
     [_] = elvis_project:git_for_deps_rebar(ElvisConfig, File, RuleConfig),
 
-    RuleConfig1 =  #{ignore => [aleppo, lager]},
+    RuleConfig1 =  #{ignore => [getopt, lager]},
     [] = elvis_project:git_for_deps_rebar(ElvisConfig, File, RuleConfig1).
 
 -spec verify_old_config_format(config()) -> any().


### PR DESCRIPTION
The rule should allow specifying which protocols (https, ssh, or git) should be allowed in the rebar.config and Makefile files for specifying dependencies.

See [this](https://github.com/inaka/erlang_guidelines/issues/27)

