### PR TITLE
Add rule checking for trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ environment values in your [configuration][config] file:
         filter => "*.erl",
         rules => [{elvis_style, line_length, #{limit => 80}},
                   {elvis_style, no_tabs},
+                  {elvis_style, no_trailing_whitespace},
                   {elvis_style, macro_names},
                   {elvis_style, macro_module_names},
                   {elvis_style, operator_spaces, #{rules => [{right, ","},

--- a/config/elvis.config
+++ b/config/elvis.config
@@ -8,6 +8,7 @@
         rules => [{elvis_style, line_length, #{limit => 80,
                                                skip_comments => false}},
                   {elvis_style, no_tabs},
+                  {elvis_style, no_trailing_whitespace},
                   {elvis_style, macro_names},
                   {elvis_style, macro_module_names},
                   {elvis_style, operator_spaces, #{rules => [{right, ","},

--- a/config/test.config
+++ b/config/test.config
@@ -8,6 +8,7 @@
         rules => [{elvis_style, line_length, #{limit => 80,
                                                skip_comments => false}},
                   {elvis_style, no_tabs},
+                  {elvis_style, no_trailing_whitespace},
                   {elvis_style, macro_names},
                   {elvis_style, macro_module_names},
                   {elvis_style, operator_spaces, #{rules => [{right, ","},

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -3,6 +3,7 @@
 -export([
          line_length/3,
          no_tabs/3,
+         no_trailing_whitespace/3,
          macro_names/3,
          macro_module_names/3,
          operator_spaces/3,
@@ -20,6 +21,8 @@
 -define(LINE_LENGTH_MSG, "Line ~p is too long: ~s.").
 
 -define(NO_TABS_MSG, "Line ~p has a tab at column ~p.").
+
+-define(NO_TRAILING_WHITESPACE_MSG, "Line ~p has trailing whitespace.").
 
 -define(INVALID_MACRO_NAME_MSG,
         "Invalid macro name ~s on line ~p. Use UPPER_CASE.").
@@ -104,6 +107,14 @@ line_length(_Config, Target, RuleConfig) ->
 no_tabs(_Config, Target, _RuleConfig) ->
     {Src, _} = elvis_file:src(Target),
     elvis_utils:check_lines(Src, fun check_no_tabs/3, []).
+
+-spec no_trailing_whitespace(elvis_config:config(),
+                             elvis_file:file(),
+                             [term()]) ->
+    [elvis_result:item()].
+no_trailing_whitespace(_Config, Target, _RuleConfig) ->
+    {Src, _} = elvis_file:src(Target),
+    elvis_utils:check_lines(Src, fun check_no_trailing_whitespace/3, []).
 
 -spec macro_names(elvis_config:config(),
                   elvis_file:file(),
@@ -389,6 +400,19 @@ check_no_tabs(Line, Num, _Args) ->
         {Index, _} ->
             Msg = ?NO_TABS_MSG,
             Info = [Num, Index],
+            Result = elvis_result:new(item, Msg, Info, Num),
+            {ok, Result}
+    end.
+
+-spec check_no_trailing_whitespace(binary(), integer(), [term()]) ->
+    no_result | {ok, elvis_result:item()}.
+check_no_trailing_whitespace(Line, Num, _Args) ->
+    case re:run(Line, "\\s+$") of
+        nomatch ->
+            no_result;
+        {match, [PosLen]} ->
+            Msg = ?NO_TRAILING_WHITESPACE_MSG,
+            Info = [PosLen, binary:part(Line, PosLen)],
             Result = elvis_result:new(item, Msg, Info, Num),
             {ok, Result}
     end.

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -22,7 +22,8 @@
 
 -define(NO_TABS_MSG, "Line ~p has a tab at column ~p.").
 
--define(NO_TRAILING_WHITESPACE_MSG, "Line ~p has trailing whitespace.").
+-define(NO_TRAILING_WHITESPACE_MSG,
+        "Line ~b has ~b trailing whitespace characters.").
 
 -define(INVALID_MACRO_NAME_MSG,
         "Invalid macro name ~s on line ~p. Use UPPER_CASE.").
@@ -110,11 +111,12 @@ no_tabs(_Config, Target, _RuleConfig) ->
 
 -spec no_trailing_whitespace(elvis_config:config(),
                              elvis_file:file(),
-                             [term()]) ->
+                             map()) ->
     [elvis_result:item()].
-no_trailing_whitespace(_Config, Target, _RuleConfig) ->
+no_trailing_whitespace(_Config, Target, RuleConfig) ->
     {Src, _} = elvis_file:src(Target),
-    elvis_utils:check_lines(Src, fun check_no_trailing_whitespace/3, []).
+    elvis_utils:check_lines(Src, fun check_no_trailing_whitespace/3,
+                            RuleConfig).
 
 -spec macro_names(elvis_config:config(),
                   elvis_file:file(),
@@ -404,15 +406,22 @@ check_no_tabs(Line, Num, _Args) ->
             {ok, Result}
     end.
 
--spec check_no_trailing_whitespace(binary(), integer(), [term()]) ->
+-spec check_no_trailing_whitespace(binary(), integer(), map()) ->
     no_result | {ok, elvis_result:item()}.
-check_no_trailing_whitespace(Line, Num, _Args) ->
-    case re:run(Line, "\\s+$") of
+check_no_trailing_whitespace(Line, Num, RuleConfig) ->
+    Regex =
+      case RuleConfig of
+        %% Lookbehind assertion: http://erlang.org/doc/man/re.html#sect17
+        #{ignore_empty_lines := true} -> "(?<=\\S)\\s+$";
+        _AnythingElse                 -> "\\s+$"
+      end,
+
+    case re:run(Line, Regex) of
         nomatch ->
             no_result;
         {match, [PosLen]} ->
             Msg = ?NO_TRAILING_WHITESPACE_MSG,
-            Info = [PosLen, binary:part(Line, PosLen)],
+            Info = [Num, size(binary:part(Line, PosLen))],
             Result = elvis_result:new(item, Msg, Info, Num),
             {ok, Result}
     end.

--- a/test/examples/fail_no_trailing_whitespace.erl
+++ b/test/examples/fail_no_trailing_whitespace.erl
@@ -1,0 +1,21 @@
+-module(fail_no_trailing_whitespace).
+
+-export([one/0, two/0, three/0, four/0, five/0]).
+
+one() ->
+    %% Following line ends with a tab
+    not_ok.	
+
+two() ->
+    %% Following line ends with a space
+    not_ok. 
+
+three() -> 
+    %% Previous line ends with a space
+    not_ok.
+ 
+four() -> %% Previous (supposedly blank) line has a space
+    not_ok.
+
+five() ->
+    ok. %% This function should be fine

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -103,9 +103,16 @@ verify_no_trailing_whitespace_rule(_Config) ->
     File = "fail_no_trailing_whitespace.erl",
     {ok, Path} = elvis_test_utils:find_file(SrcDirs, File),
 
-    Items = elvis_style:no_trailing_whitespace(ElvisConfig, Path, #{}),
-    length(Items) == 4 orelse
-        ct:fail("Expected 4 error items. Got: ~p", [Items]).
+    do_verify_no_trailing_whitespace(Path, ElvisConfig,
+                                     #{ignore_empty_lines => true}, 3),
+    do_verify_no_trailing_whitespace(Path, ElvisConfig,
+                                     #{ignore_empty_lines => false}, 4),
+    do_verify_no_trailing_whitespace(Path, ElvisConfig, #{}, 4).
+
+do_verify_no_trailing_whitespace(Path, Config, RuleConfig, ExpectedNumItems) ->
+    Items = elvis_style:no_trailing_whitespace(Config, Path, RuleConfig),
+    length(Items) == ExpectedNumItems orelse
+        ct:fail("Expected ~b error items. Got: ~p", [ExpectedNumItems, Items]).
 
 -spec verify_macro_names_rule(config()) -> any().
 verify_macro_names_rule(_Config) ->

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -9,6 +9,7 @@
 -export([
          verify_line_length_rule/1,
          verify_no_tabs_rule/1,
+         verify_no_trailing_whitespace_rule/1,
          verify_macro_names_rule/1,
          verify_macro_module_names/1,
          verify_operator_spaces/1,
@@ -93,6 +94,18 @@ verify_no_tabs_rule(_Config) ->
     {ok, Path} = elvis_test_utils:find_file(SrcDirs, File),
 
     [_, _] = elvis_style:no_tabs(ElvisConfig, Path, #{}).
+
+-spec verify_no_trailing_whitespace_rule(config()) -> any().
+verify_no_trailing_whitespace_rule(_Config) ->
+    ElvisConfig = elvis_config:default(),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    File = "fail_no_trailing_whitespace.erl",
+    {ok, Path} = elvis_test_utils:find_file(SrcDirs, File),
+
+    Items = elvis_style:no_trailing_whitespace(ElvisConfig, Path, #{}),
+    length(Items) == 4 orelse
+        ct:fail("Expected 4 error items. Got: ~p", [Items]).
 
 -spec verify_macro_names_rule(config()) -> any().
 verify_macro_names_rule(_Config) ->


### PR DESCRIPTION
This rule is based on the no_tabs rule, but checks for trailing
whitespace instead. The 'info' field of the elvis items returned contain
the position, length, and the contents of the matched trailing
whitespace. It could be useful for debugging.