### PR TITLE
Use https instead of git remotes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,16 @@ PROJECT = elvis
 DEPS = lager sync getopt jiffy ibrowse aleppo zipper egithub katana
 TEST_DEPS = meck
 
-dep_lager = git git://github.com/basho/lager.git 2.0.3
-dep_sync = git git://github.com/inaka/sync.git 0.1.3
-dep_getopt = git git://github.com/jcomellas/getopt v0.8.2
-dep_meck = git git://github.com/eproxus/meck 0.8.2
-dep_jiffy = git git://github.com/davisp/jiffy 0.14.2
-dep_ibrowse = git git://github.com/cmullaparthi/ibrowse v4.1.2
-dep_aleppo = git git://github.com/inaka/aleppo 0.9.1
-dep_zipper = git git://github.com/inaka/zipper 0.1.2
-dep_egithub = git git://github.com/inaka/erlang-github 0.1.7
-dep_katana =  git git://github.com/inaka/erlang-katana 0.2.7
+dep_lager = git https://github.com/basho/lager.git 2.0.3
+dep_sync = git https://github.com/inaka/sync.git 0.1.3
+dep_getopt = git https://github.com/jcomellas/getopt v0.8.2
+dep_meck = git https://github.com/eproxus/meck 0.8.2
+dep_jiffy = git https://github.com/davisp/jiffy 0.14.2
+dep_ibrowse = git https://github.com/cmullaparthi/ibrowse v4.1.2
+dep_aleppo = git https://github.com/inaka/aleppo 0.9.1
+dep_zipper = git https://github.com/inaka/zipper 0.1.2
+dep_egithub = git https://github.com/inaka/erlang-github 0.1.7
+dep_katana =  git https://github.com/inaka/erlang-katana 0.2.7
 
 include erlang.mk
 

--- a/rebar.config
+++ b/rebar.config
@@ -21,15 +21,15 @@
 {deps_dir, "deps"}.
 {deps,
  [
-  {lager,   "2.*", {git, "git://github.com/basho/lager.git",          "2.0.0"}},
-  {getopt,  "0.*", {git, "git://github.com/jcomellas/getopt.git",     "v0.8.2"}},
-  {meck,    "0.*", {git, "git://github.com/eproxus/meck.git",         "0.8.2"}},
-  {jiffy,   "0.*", {git, "git://github.com/davisp/jiffy.git",         "0.14.2"}},
-  {ibrowse, "4.*", {git, "git://github.com/cmullaparthi/ibrowse.git", "v4.1.2"}},
-  {aleppo,  "0.*", {git, "git://github.com/inaka/aleppo.git",         "0.9.0"}},
-  {zipper,  ".*",  {git, "git://github.com/inaka/zipper.git",         "0.1.0"}},
-  {egithub, ".*",  {git, "git://github.com/inaka/erlang-github.git",  "0.1.1"}},
-  {katana,  ".*",  {git, "git://github.com/inaka/erlang-katana",      "0.2.0"}}
+  {lager,   "2.*", {git, "https://github.com/basho/lager.git",          "2.0.0"}},
+  {getopt,  "0.*", {git, "https://github.com/jcomellas/getopt.git",     "v0.8.2"}},
+  {meck,    "0.*", {git, "https://github.com/eproxus/meck.git",         "0.8.2"}},
+  {jiffy,   "0.*", {git, "https://github.com/davisp/jiffy.git",         "0.14.2"}},
+  {ibrowse, "4.*", {git, "https://github.com/cmullaparthi/ibrowse.git", "v4.1.2"}},
+  {aleppo,  "0.*", {git, "https://github.com/inaka/aleppo.git",         "0.9.0"}},
+  {zipper,  ".*",  {git, "https://github.com/inaka/zipper.git",         "0.1.0"}},
+  {egithub, ".*",  {git, "https://github.com/inaka/erlang-github.git",  "0.1.1"}},
+  {katana,  ".*",  {git, "https://github.com/inaka/erlang-katana.git",  "0.2.0"}}
  ]
 }.
 {escript_name, "elvis"}.

--- a/src/elvis_project.erl
+++ b/src/elvis_project.erl
@@ -72,7 +72,7 @@ git_for_deps_rebar(Config, Target, RuleConfig) ->
     [elvis_result:item()].
 protocol_for_deps_rebar(_Config, Target, RuleConfig) ->
     IgnoreDeps = maps:get(ignore, RuleConfig, []),
-    Regex = maps:get(regex, RuleConfig, "git://.*"),
+    Regex = maps:get(regex, RuleConfig, "https://.*"),
     Deps = get_rebar_deps(Target),
     BadDeps = lists:filter(fun(Dep) -> is_rebar_not_git_dep(Dep, Regex) end,
                            Deps),

--- a/test/examples/rebar.config.fail
+++ b/test/examples/rebar.config.fail
@@ -21,12 +21,12 @@
 {deps_dir, "deps"}.
 {deps,
  [
-  {lager, "2.*", {git, "https://github.com/basho/lager.git", "2.0.0"}},
+  {lager, "2.*", {git, "git://github.com/basho/lager.git", "2.0.0"}},
   {getopt, "0.*", {git, "git@github.com:jcomellas/getopt.git", {branch, "master"}}},
-  {meck, "0.*", {git, "git://github.com/eproxus/meck.git", "0.8.2"}},
-  {jiffy, "0.*", {git, "git://github.com/davisp/jiffy.git", "0.11.3"}},
-  {ibrowse, "4.*", {git, "git://github.com/cmullaparthi/ibrowse.git", "v4.1.1"}},
-  {aleppo, "0.*", {git, "git://github.com/inaka/aleppo.git", "master"}}
+  {meck, "0.*", {git, "https://github.com/eproxus/meck.git", "0.8.2"}},
+  {jiffy, "0.*", {git, "https://github.com/davisp/jiffy.git", "0.11.3"}},
+  {ibrowse, "4.*", {git, "https://github.com/cmullaparthi/ibrowse.git", "v4.1.1"}},
+  {aleppo, "0.*", {git, "https://github.com/inaka/aleppo.git", "master"}}
  ]
 }.
 {escript_name, "elvis"}.


### PR DESCRIPTION
Trying to use apns4erl I'm getting this problem:

```
* katana (https://github.com/inaka/erlang-katana.git)
  the dependency katana in deps/apns/rebar.config is overriding a child dependency:

  > In deps/apns/rebar.config:
    {:katana, ~r/.*/, [git: "https://github.com/inaka/erlang-katana.git", tag: "0.2.0"]}

  > In deps/elvis/rebar.config:
    {:katana, ~r/.*/, [git: "git://github.com/inaka/erlang-katana", ref: "0.2.0"]}
```

So I'm trying to normalize it as `https` in the all sub-dependencies of apns4erl since https is the protocol recommended by github on remotes.