### PR TITLE
Support for Rebar3 style deps

### DIFF
--- a/src/elvis_project.erl
+++ b/src/elvis_project.erl
@@ -148,6 +148,12 @@ get_rebar_deps(File) ->
         [{deps, Deps}] -> Deps
     end.
 
+%% Rebar3
+is_rebar_master_dep({_AppName, {_SCM, _Location, "master"}}) ->
+    true;
+is_rebar_master_dep({_AppName, {_SCM, _Location, {branch, "master"}}}) ->
+    true;
+%% Rebar2
 is_rebar_master_dep({_AppName, _Vsn, {_SCM, _Location, "master"}}) ->
     true;
 is_rebar_master_dep({_AppName, _Vsn, {_SCM, _Location, {branch, "master"}}}) ->
@@ -155,19 +161,26 @@ is_rebar_master_dep({_AppName, _Vsn, {_SCM, _Location, {branch, "master"}}}) ->
 is_rebar_master_dep(_) ->
     false.
 
+is_rebar_not_git_dep({_AppName, {_SCM, Url, _Branch}}, Regex) ->
+    nomatch == re:run(Url, Regex, []);
 is_rebar_not_git_dep({_AppName, _Vsn, {_SCM, Url, _Branch}}, Regex) ->
     nomatch == re:run(Url, Regex, []).
 
-rebar_dep_to_result({AppName, _, _}, Message, {IgnoreDeps, Regex}) ->
-    case lists:member(AppName, IgnoreDeps) of
-        true -> [];
-        false -> [elvis_result:new(item, Message, [AppName, Regex])]
-    end;
-rebar_dep_to_result({AppName, _, _}, Message, IgnoreDeps) ->
-    case lists:member(AppName, IgnoreDeps) of
-        true -> [];
-        false -> [elvis_result:new(item, Message, [AppName])]
-    end.
+rebar_dep_to_result({AppName, _}, Message, {IgnoreDeps, Regex}) ->
+  case lists:member(AppName, IgnoreDeps) of
+    true -> [];
+    false -> [elvis_result:new(item, Message, [AppName, Regex])]
+  end;
+rebar_dep_to_result({AppName, _}, Message, IgnoreDeps) ->
+  case lists:member(AppName, IgnoreDeps) of
+    true -> [];
+    false -> [elvis_result:new(item, Message, [AppName])]
+  end;
+rebar_dep_to_result({AppName, _, GitInfo}, Message, {IgnoreDeps, Regex}) ->
+  rebar_dep_to_result({AppName, GitInfo}, Message, {IgnoreDeps, Regex});
+rebar_dep_to_result({AppName, _, GitInfo}, Message, IgnoreDeps) ->
+  rebar_dep_to_result({AppName, GitInfo}, Message, IgnoreDeps).
+
 
 
 %%% erlang.mk

--- a/test/examples/rebar.config.fail
+++ b/test/examples/rebar.config.fail
@@ -26,7 +26,14 @@
   {meck, "0.*", {git, "https://github.com/eproxus/meck.git", "0.8.2"}},
   {jiffy, "0.*", {git, "https://github.com/davisp/jiffy.git", "0.11.3"}},
   {ibrowse, "4.*", {git, "https://github.com/cmullaparthi/ibrowse.git", "v4.1.1"}},
-  {aleppo, "0.*", {git, "https://github.com/inaka/aleppo.git", "master"}}
+  {aleppo, "0.*", {git, "https://github.com/inaka/aleppo.git", "master"}},
+
+  {lager, {git, "git://github.com/basho/lager.git", "2.0.0"}},
+  {getopt, {git, "git@github.com:jcomellas/getopt.git", {branch, "master"}}},
+  {meck, {git, "https://github.com/eproxus/meck.git", "0.8.2"}},
+  {jiffy, {git, "https://github.com/davisp/jiffy.git", "0.11.3"}},
+  {ibrowse, {git, "https://github.com/cmullaparthi/ibrowse.git", "v4.1.1"}},
+  {aleppo, {git, "https://github.com/inaka/aleppo.git", "master"}}
  ]
 }.
 {escript_name, "elvis"}.

--- a/test/project_SUITE.erl
+++ b/test/project_SUITE.erl
@@ -78,10 +78,10 @@ verify_no_deps_master_rebar(_Config) ->
     Filename = "rebar.config.fail",
     {ok, File} = elvis_test_utils:find_file(SrcDirs, Filename),
 
-    [_, _] = elvis_project:no_deps_master_rebar(ElvisConfig, File, #{}),
+    [_, _, _, _] = elvis_project:no_deps_master_rebar(ElvisConfig, File, #{}),
 
     RuleConfig =  #{ignore => [aleppo]},
-    [_] = elvis_project:no_deps_master_rebar(ElvisConfig, File, RuleConfig),
+    [_, _] = elvis_project:no_deps_master_rebar(ElvisConfig, File, RuleConfig),
 
     RuleConfig1 =  #{ignore => [aleppo, getopt]},
     [] = elvis_project:no_deps_master_rebar(ElvisConfig, File, RuleConfig1).
@@ -147,16 +147,16 @@ verify_git_for_deps_rebar(_Config) ->
     Filename = "rebar.config.fail",
     {ok, File} = elvis_test_utils:find_file(SrcDirs, Filename),
 
-    [_, _] = elvis_project:git_for_deps_rebar(ElvisConfig, File, #{}),
+    [_, _, _, _] = elvis_project:git_for_deps_rebar(ElvisConfig, File, #{}),
 
     RuleConfig =  #{ignore => [getopt]},
-    [_] = elvis_project:git_for_deps_rebar(ElvisConfig, File, RuleConfig),
+    [_, _] = elvis_project:git_for_deps_rebar(ElvisConfig, File, RuleConfig),
 
     RuleConfig1 =  #{ignore => [getopt, lager]},
     [] = elvis_project:git_for_deps_rebar(ElvisConfig, File, RuleConfig1),
 
     RuleConfig2 =  #{ignore => [meck], regex => "git@.*"},
-    [_, _, _, _] =
+    [_, _, _, _, _, _, _, _] =
         elvis_project:git_for_deps_rebar(ElvisConfig, File, RuleConfig2).
 
 -spec verify_protocol_for_deps_rebar(config()) -> any().
@@ -167,16 +167,16 @@ verify_protocol_for_deps_rebar(_Config) ->
     Filename = "rebar.config.fail",
     {ok, File} = elvis_test_utils:find_file(SrcDirs, Filename),
 
-    [_, _] = elvis_project:protocol_for_deps_rebar(ElvisConfig, File, #{}),
+    [_, _, _, _] = elvis_project:protocol_for_deps_rebar(ElvisConfig, File, #{}),
 
     RuleConfig =  #{ignore => [getopt]},
-    [_] = elvis_project:protocol_for_deps_rebar(ElvisConfig, File, RuleConfig),
+    [_, _] = elvis_project:protocol_for_deps_rebar(ElvisConfig, File, RuleConfig),
 
     RuleConfig1 =  #{ignore => [getopt, lager]},
     [] = elvis_project:protocol_for_deps_rebar(ElvisConfig, File, RuleConfig1),
 
     RuleConfig2 =  #{ignore => [meck], regex => "git@.*"},
-    [_, _, _, _] =
+    [_, _, _, _, _, _, _, _] =
         elvis_project:protocol_for_deps_rebar(ElvisConfig, File, RuleConfig2).
 
 -spec verify_old_config_format(config()) -> any().


### PR DESCRIPTION
Elvis fails on a rebar.config file which uses Rebar3 style deps with the following error.

```
# rebar.config [FAIL]
Error: 'function_clause' while applying rule 'protocol_for_deps_rebar'.
Loading files...
Applying rules...
```

This is the style which it fails on.
```
{deps, [
  {poolboy, {git, "https://github.com/devinus/poolboy.git", {tag, "1.5.1"}}},
  {gproc,   {git, "https://github.com/uwiger/gproc.git", {branch, "master"}}}
]
}.
```