### PR TITLE
[Closes #258] Updated katana dep which handles changes in OTP 18.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,19 @@
 PROJECT = elvis
 
-DEPS = lager sync getopt jiffy ibrowse aleppo zipper egithub katana
-TEST_DEPS = meck xref_runner
+DEPS = lager sync getopt jiffy ibrowse zipper egithub katana
 
 dep_lager = git https://github.com/basho/lager.git 2.0.3
 dep_sync = git https://github.com/inaka/sync.git 0.1.3
 dep_getopt = git https://github.com/jcomellas/getopt v0.8.2
-dep_meck = git https://github.com/eproxus/meck 0.8.2
 dep_jiffy = git https://github.com/davisp/jiffy 0.14.2
 dep_ibrowse = git https://github.com/cmullaparthi/ibrowse v4.1.2
-dep_aleppo = git https://github.com/inaka/aleppo 0.9.1
 dep_zipper = git https://github.com/inaka/zipper 0.1.2
 dep_egithub = git https://github.com/inaka/erlang-github 0.1.7
-dep_katana =  git https://github.com/inaka/erlang-katana 0.2.10
+dep_katana =  git https://github.com/inaka/erlang-katana 0.2.13
+
+TEST_DEPS = meck xref_runner
+
+dep_meck = git https://github.com/eproxus/meck 0.8.3
 dep_xref_runner = git https://github.com/inaka/xref_runner.git 0.2.2
 
 include erlang.mk
@@ -25,7 +26,7 @@ ERLC_OPTS += +warn_export_vars +warn_exported_vars +warn_missing_spec +warn_unty
 # Commont Test Config
 
 TEST_ERLC_OPTS += +'{parse_transform, lager_transform}'
-CT_OPTS = -cover test/elvis.coverspec  -erl_args -config config/test.config
+CT_OPTS = -cover test/elvis.coverspec -erl_args -config config/test.config
 
 # Builds the elvis escript.
 escript: all
@@ -36,7 +37,7 @@ shell: app
 	erl -pa ebin -pa deps/*/ebin -name elvis@`hostname` -s sync -s elvis -s lager -config config/elvis.config
 
 test-shell: build-ct-suites app
-	erl -pa ebin -pa deps/*/ebin -pa test -s sync -s elvis -s lager -config config/elvis.config
+	erl -pa ebin -pa deps/*/ebin -name elvis-test@`hostname` -pa test -s sync -s elvis -s lager -config config/test.config
 
 install: escript
 	cp elvis /usr/local/bin


### PR DESCRIPTION
#258 

Also removed unnecessary dependency `aleppo` and updated test dep `meck` so that it doesn't run `doc` and `test` targets on `make all`.