### PR TITLE
Wrong config spec

### DIFF
--- a/src/elvis_config.erl
+++ b/src/elvis_config.erl
@@ -21,7 +21,7 @@
               config/0
              ]).
 
--type config() :: map().
+-type config() :: [map()].
 
 -define(DEFAULT_CONFIG_PATH, "./elvis.config").
 -define(DEFAULT_FILTER, "*.erl").


### PR DESCRIPTION
In `elvis_config` you'll find
```erlang
-type config() :: map().
```
when in fact it should be
```erlang
-type config() :: [map()].
```