### PR TITLE
Fix line length for unicode files

### DIFF
--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -670,7 +670,8 @@ check_line_length(Line, Num, [Limit, any]) ->
 check_line_length(Line, Num, [Limit|_]) ->
     check_line_length(Line, Num, Limit);
 check_line_length(Line, Num, Limit) ->
-    case byte_size(Line) of
+    Chars = unicode:characters_to_list(Line),
+    case length(Chars) of
         Large when Large > Limit ->
             Msg = ?LINE_LENGTH_MSG,
             Info = [Num, binary_to_list(Line)],


### PR DESCRIPTION
The original implementaiton used byte_size for line length, however
this gave false results for unicode files. In the end we are not
interested in the number of bytes but the number of characters.