### PR TITLE
variable_naming_convention and MACROs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TEST_DEPS = katana_test mixer meck xref_runner
 BUILD_DEPS = inaka_mk hexer_mk
 DEP_PLUGINS = inaka_mk hexer_mk
 
-dep_elvis_core  = git https://github.com/inaka/elvis_core      0.2.11
+dep_elvis_core  = git https://github.com/inaka/elvis_core      592a5d8
 dep_getopt      = hex 0.8.2
 dep_jiffy       = hex 0.14.7
 dep_egithub     = hex 0.2.2

--- a/rebar.config
+++ b/rebar.config
@@ -21,7 +21,7 @@
 {deps,
  [
   {lager,       ".*",  {git, "https://github.com/basho/lager.git",          "3.0.2"}},
-  {elvis_core,  ".*",  {git, "https://github.com/inaka/elvis_core",         "0.2.11"}},
+  {elvis_core,  ".*",  {git, "https://github.com/inaka/elvis_core",         "592a5d8"}},
   {getopt,      "0.*", {git, "https://github.com/jcomellas/getopt.git",     "v0.8.2"}},
   {meck,        "0.*", {git, "https://github.com/eproxus/meck.git",         "0.8.4"}},
   {jiffy,       "0.*", {git, "https://github.com/davisp/jiffy.git",         "0.14.3"}},


### PR DESCRIPTION
the `variable_naming_convention` rule complains incorrectly about MACRO names