### PR TITLE
Add option for running Elvis on all changes since branch or commit

### DIFF
--- a/src/elvis.erl
+++ b/src/elvis.erl
@@ -115,6 +115,9 @@ process_commands(['install', 'git-hook' | Cmds], Config) ->
 process_commands(['git-hook' | Cmds], Config) ->
     elvis_git:run_hook(Config),
     process_commands(Cmds, Config);
+process_commands(['git-branch', Commit | Cmds], Config) ->
+    elvis_git:run_branch(atom_to_list(Commit), Config),
+    process_commands(Cmds, Config);
 process_commands([], _Config) ->
     ok;
 process_commands([_Cmd | _Cmds], _Config) ->
@@ -142,6 +145,11 @@ rock [file...]   Rock your socks off by running all rules to your source files.
 git-hook         Pre-commit Git Hook: Gets all staged files and runs the rules
                                       specified in the configuration to those
                                       files.
+
+git-branch [branch|commit]
+                 Rock your socks off by running all rules on source files that
+                 have changed since branch or commit.
+
 install git-hook
                 Installs Elvis as a pre-commit hook in your current working
                 directory, which should be a git repository.


### PR DESCRIPTION
Expand elvis with an option to run Elvis on all changes since a particular branch or sha. I would like to be able to run elvis on a Jenkins run and would like to get the entire diff of the branch rather than as a commit-hook or webhook (which doesn't work for in-house hosted Bitbucket server)

Example:
`elvis git-branch origin/master`
`elvis git-branch a441b15`

Fixes: #420