### PR TITLE
Add --keep-rocking switch

### DIFF
--- a/src/elvis.erl
+++ b/src/elvis.erl
@@ -53,20 +53,28 @@ main(Args) ->
 -spec option_spec_list() -> [getopt:option_spec()].
 option_spec_list() ->
     Commands = "Provide the path to the configuration file. "
-               ++ "When none is provided elvis checks if there's "
-               ++ "an elvis.config file.",
+               "When none is provided elvis checks if there's "
+               "an elvis.config file.",
     OutputFormat = "It allows you to display the results in plain text. When "
-                   ++ "none is provided elvis displays the results in colors. "
-                   ++ "The options allowed are (plain | colors).",
-    KeepGoing = "Won't stop rocking on first error when given a list of files",
+                   "none is provided elvis displays the results in colors. "
+                   "The options allowed are (plain | colors).",
+    KeepRocking = "Won't stop rocking on first error"
+                  " when given a list of files",
     [
-     {help, $h, "help", undefined, "Show this help information."},
-     {config, $c, "config", string, Commands},
-     {commands, undefined, "commands", undefined, "Show available commands."},
-     {output_format, undefined, "output-format", string, OutputFormat},
-     {version, $v, "version", undefined, "Specify the elvis current version."},
-     {code_path, $p, "code-path", string, "Add the directory in the code path."},
-     {keep_going, $k, "keep-going", undefined, KeepGoing}
+     {help, $h, "help", undefined,
+      "Show this help information."},
+     {config, $c, "config", string,
+      Commands},
+     {commands, undefined, "commands", undefined,
+      "Show available commands."},
+     {output_format, undefined, "output-format", string,
+      OutputFormat},
+     {version, $v, "version", undefined,
+      "Specify the elvis current version."},
+     {code_path, $p, "code-path", string,
+      "Add the directory in the code path."},
+     {keep_rocking, $k, "keep-rocking", undefined,
+      KeepRocking}
     ].
 
 -spec process_options([atom()], [string()]) -> ok.
@@ -95,8 +103,8 @@ process_options([commands | Opts], Cmds, Config) ->
 process_options([{output_format, Format} | Opts], Cmds, Config) ->
     ok = application:set_env(elvis, output_format, list_to_atom(Format)),
     process_options(Opts, Cmds, Config);
-process_options([keep_going | Opts], Cmds, Config) ->
-    ok = application:set_env(elvis, keep_going, true),
+process_options([keep_rocking | Opts], Cmds, Config) ->
+    ok = application:set_env(elvis, keep_rocking, true),
     process_options(Opts, Cmds, Config);
 process_options([version | Opts], Cmds, Config) ->
     version(),
@@ -187,7 +195,7 @@ rock_one_song(FileName, Config) ->
     F = atom_to_list(FileName),
     case elvis_core:rock_this(F, Config) of
         {fail, _} ->
-            case application:get_env(elvis, keep_going, false) of
+            case application:get_env(elvis, keep_rocking, false) of
                 false -> elvis_utils:erlang_halt(1);
                 true -> ok
             end;

--- a/src/elvis.erl
+++ b/src/elvis.erl
@@ -58,13 +58,15 @@ option_spec_list() ->
     OutputFormat = "It allows you to display the results in plain text. When "
                    ++ "none is provided elvis displays the results in colors. "
                    ++ "The options allowed are (plain | colors).",
+    KeepGoing = "Won't stop rocking on first error when given a list of files",
     [
      {help, $h, "help", undefined, "Show this help information."},
      {config, $c, "config", string, Commands},
      {commands, undefined, "commands", undefined, "Show available commands."},
      {output_format, undefined, "output-format", string, OutputFormat},
      {version, $v, "version", undefined, "Specify the elvis current version."},
-     {code_path, $p, "code-path", string, "Add the directory in the code path."}
+     {code_path, $p, "code-path", string, "Add the directory in the code path."},
+     {keep_going, $k, "keep-going", undefined, KeepGoing}
     ].
 
 -spec process_options([atom()], [string()]) -> ok.
@@ -92,6 +94,9 @@ process_options([commands | Opts], Cmds, Config) ->
     process_options(Opts, Cmds, Config);
 process_options([{output_format, Format} | Opts], Cmds, Config) ->
     ok = application:set_env(elvis, output_format, list_to_atom(Format)),
+    process_options(Opts, Cmds, Config);
+process_options([keep_going | Opts], Cmds, Config) ->
+    ok = application:set_env(elvis, keep_going, true),
     process_options(Opts, Cmds, Config);
 process_options([version | Opts], Cmds, Config) ->
     version(),
@@ -181,6 +186,10 @@ version() ->
 rock_one_song(FileName, Config) ->
     F = atom_to_list(FileName),
     case elvis_core:rock_this(F, Config) of
-        {fail, _} -> elvis_utils:erlang_halt(1);
+        {fail, _} ->
+            case application:get_env(elvis, keep_going, false) of
+                false -> elvis_utils:erlang_halt(1);
+                true -> ok
+            end;
         ok -> ok
     end.


### PR DESCRIPTION
This switch will force Elvis to keep rocking even when it encounters an error. It applies to a case when a list of files to rock is provided. Default behaviour causes the script to stop on first faulty module.

It's useful for rocking group of modules selected with regexp. First of all, it allows to learn an overview of errors in all modules. Secondly, now it's possible to ignore some errors that are tricky to resolve (like god modules) and continue to remaining mods.