### PR TITLE
Add `--verbose` flag, setting verbose app env option

### DIFF
--- a/src/elvis.erl
+++ b/src/elvis.erl
@@ -69,6 +69,8 @@ option_spec_list() ->
       "Show available commands."},
      {output_format, undefined, "output-format", string,
       OutputFormat},
+     {verbose, $V, "verbose", undefined,
+      "Enable verbose output."},
      {version, $v, "version", undefined,
       "Specify the elvis current version."},
      {code_path, $p, "code-path", string,
@@ -105,6 +107,9 @@ process_options([{output_format, Format} | Opts], Cmds, Config) ->
     process_options(Opts, Cmds, Config);
 process_options([keep_rocking | Opts], Cmds, Config) ->
     ok = application:set_env(elvis, keep_rocking, true),
+    process_options(Opts, Cmds, Config);
+process_options([verbose | Opts], Cmds, Config) ->
+    ok = application:set_env(elvis, verbose, true),
     process_options(Opts, Cmds, Config);
 process_options([version | Opts], Cmds, Config) ->
     version(),

--- a/src/elvis.erl
+++ b/src/elvis.erl
@@ -69,6 +69,8 @@ option_spec_list() ->
       "Show available commands."},
      {output_format, undefined, "output-format", string,
       OutputFormat},
+     {quiet, $q, "quiet", undefined,
+      "Suppress all output."},
      {verbose, $V, "verbose", undefined,
       "Enable verbose output."},
      {version, $v, "version", undefined,
@@ -107,6 +109,9 @@ process_options([{output_format, Format} | Opts], Cmds, Config) ->
     process_options(Opts, Cmds, Config);
 process_options([keep_rocking | Opts], Cmds, Config) ->
     ok = application:set_env(elvis, keep_rocking, true),
+    process_options(Opts, Cmds, Config);
+process_options([quiet | Opts], Cmds, Config) ->
+    ok = application:set_env(elvis, no_output, true),
     process_options(Opts, Cmds, Config);
 process_options([verbose | Opts], Cmds, Config) ->
     ok = application:set_env(elvis, verbose, true),

--- a/src/elvis.erl
+++ b/src/elvis.erl
@@ -72,7 +72,7 @@ option_spec_list() ->
      {verbose, $V, "verbose", undefined,
       "Enable verbose output."},
      {version, $v, "version", undefined,
-      "Specify the elvis current version."},
+      "Output the current elvis version."},
      {code_path, $p, "code-path", string,
       "Add the directory in the code path."},
      {keep_rocking, $k, "keep-rocking", undefined,


### PR DESCRIPTION
Now with the corresponding [elvis_core PR](https://github.com/inaka/elvis_core/pull/88), it'll behave as follows:

```interactive
$ elvis --output-format plain --verbose rock
Loading files...
Loading src/elvis.erl
Loading src/elvis_git.erl
Loading src/elvis_webhook.erl
Loading test/elvis_SUITE.erl
Loading test/elvis_meta_SUITE.erl
Loading test/git_SUITE.erl
Loading test/xref_SUITE.erl
Applying rules...
# src/elvis.erl [FAIL]
  - no_tabs
    - Line 18 has a tab at column 0.
# src/elvis_git.erl [OK]
# src/elvis_webhook.erl [OK]
# test/elvis_SUITE.erl [OK]
# test/elvis_meta_SUITE.erl [OK]
# test/git_SUITE.erl [OK]
# test/xref_SUITE.erl [OK]
Loading files...
Applying rules...
Loading files...
Loading rebar.config
Applying rules...
# rebar.config [OK]
Loading files...
Loading elvis.config
Applying rules...
# elvis.config [OK]
$
```

vs

```interactive
$ elvis --output-format plain rock
# src/elvis.erl [FAIL]
  - no_tabs
    - Line 18 has a tab at column 0.
$
```

I've also thought that it might make sense to expose the existing `no_output` app env setting, via `-q`:


```interactive
$ elvis -q rock
$ echo $?
1
$
```