### PR TITLE
Add git-branch option for elvis escript to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ otherwise a configuration file can be specified through the use of the
 elvis rock --config config/elvis.config
 ```
 
+In `0.3.0` a new option was introduced in order to run elvis checks only on the source files that have changed since a particular branch of commit. Example usage would be `elvis git-branch origin/HEAD`.
+
 ### Webhook
 
 There's also a way to use `elvis` as a GitHub [webhook][webhooks] for


### PR DESCRIPTION
I realized that when I introduced the git-branch option a while ago, I didn't add it to the README. The only way it's documented as of now is if you run elvis --commands. I believe this option is beneficial for quite some projects so it'd be nice to have it slightly more prominent in the README.