### PR TITLE
Prevent a minor warning (and prepare for the future)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,7 +23,7 @@
 {profiles, [
   {test, [
     {deps, [ {mixer,       "1.0.0", {pkg, inaka_mixer}}
-           , {meck,        "0.8.10"}
+           , {meck,        "0.9.0"}
            , {xref_runner, "1.1.0"}
     ]}
   ]}


### PR DESCRIPTION
Warning is `Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace`.