### PR TITLE
Prevent eunit issues + Rock with Elvis

### DIFF
--- a/ci
+++ b/ci
@@ -5,3 +5,5 @@ set -ex
 rebar3 deps
 rebar3 dialyzer -u true -s false
 rebar3 ct
+rebar3 escriptize
+_build/default/bin/elvis rock

--- a/rebar.config
+++ b/rebar.config
@@ -22,6 +22,7 @@
 
 {profiles, [
   {test, [
+    {extra_src_dirs, [{"test/examples", [{recursive, true}]}]},
     {deps, [ {mixer,       "1.0.0", {pkg, inaka_mixer}}
            , {meck,        "0.9.0"}
            , {xref_runner, "1.1.0"}

--- a/test/examples/fail_dont_repeat_yourself.erl
+++ b/test/examples/fail_dont_repeat_yourself.erl
@@ -5,6 +5,7 @@
          repeated_complexity_10/2
         ]).
 
+-spec repeated_complexity_5(any(), any()) -> [any(), ...].
 repeated_complexity_5(X, Y) ->
     Z = X ++ [ok],
     W = Y ++ [ok],

--- a/test/examples/user_defined_rules.erl
+++ b/test/examples/user_defined_rules.erl
@@ -2,5 +2,6 @@
 
 -export([rule/3]).
 
+-spec rule(any(), any(), any()) -> [elvis_result:item(), ...].
 rule(_Config, _Target, _) ->
     [elvis_result:new(item, "This will always FAIL.", [], 1)].


### PR DESCRIPTION
Though `eunit` tests aren't present, it's still possible to prevent issues for them with these minor changes; otherwise they show up as errors and this might confuse the developer.

I took the time to add `elvis` to CI, for increased goodness.