### PR TITLE
Hide API Reference from hexdocs.pm

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -38,7 +38,8 @@
  [{source_url, <<"https://github.com/inaka/elvis">>},
   {extras, [<<"README.md">>, <<"LICENSE">>]},
   {main, <<"README.md">>},
-  {prefix_ref_vsn_with_v, false}]}.
+  {prefix_ref_vsn_with_v, false},
+  {api_reference, false}]}.
 
 {hex, [{doc, #{provider => ex_doc}}]}.
 


### PR DESCRIPTION
There's no real value in the documentation of the API since this is not a consumable dependency, but more like a local service.