### PR TITLE
Fix CI execution conditions: pull request + push to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,13 @@
 ---
 name: build
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - "*"
+  workflow_dispatch: {}
 jobs:
   ci:
     name: Run checks and tests over ${{matrix.otp_vsn}}


### PR DESCRIPTION
We're making sure pushing to the main branch, as well as pull requests, and workflow dispatches, trigger CI.
